### PR TITLE
coveralls-lcov to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,15 @@ before_install:
   - gem install coveralls-lcov
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -e
-    TRAVIS="${TRAVIS}" -e
-    TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -e
-    TRAVIS_BRANCH="${TRAVIS_BRANCH}" -e
-    TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR}" -e
-    COVERALLS_REPO_TOKEN="${COVERALLS_REPO_TOKEN}" --entrypoint=$TRAVIS_BUILD_DIR/build-in-docker.sh
+  - docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR
+    -e TRAVIS
+    -e TRAVIS_REPO_SLUG
+    -e TRAVIS_JOB_ID
+    -e TRAVIS_PULL_REQUEST
+    -e TRAVIS_BRANCH
+    -e COVERALLS_REPO_TOKEN
+    --entrypoint=$TRAVIS_BUILD_DIR/build-in-docker.sh
     loonygnoll/lemongrab-build-gentoo
-  - coveralls-lcov --repo-token "${COVERALLS_REPO_TOKEN}" build/coverage.clean.info
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 
 script:
   - docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR
+    -e TRAVIS_BUILD_DIR
     -e TRAVIS
     -e TRAVIS_REPO_SLUG
     -e TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 
 before_install:
   - docker pull loonygnoll/lemongrab-build-gentoo
-  - gem install coveralls-lcov
 
 script:
   - docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -11,4 +11,4 @@ mkdir testdb
 ./lemongrab --test
 lcov -c -d . -o coverage.info
 lcov --remove coverage.info "/usr*" -o coverage.clean.info
-coveralls-lcov --repo-token "${COVERALLS_REPO_TOKEN}" build/coverage.clean.info
+coveralls-lcov --repo-token "${COVERALLS_REPO_TOKEN}" coverage.clean.info

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -11,4 +11,4 @@ mkdir testdb
 ./lemongrab --test
 lcov -c -d . -o coverage.info
 lcov --remove coverage.info "/usr*" -o coverage.clean.info
-chmod -R 777 ${TRAVIS_BUILD_DIR}
+coveralls-lcov --repo-token "${COVERALLS_REPO_TOKEN}" build/coverage.clean.info


### PR DESCRIPTION
An attempt to move coveralls-lcov execution directly to the docker container in order to avoid `777` hacks.